### PR TITLE
Add Jellyfin 10.11 compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.2.0.0</Version>
-        <AssemblyVersion>1.2.0.0</AssemblyVersion>
-        <FileVersion>1.2.0.0</FileVersion>
+        <Version>1.3.0.0</Version>
+        <AssemblyVersion>1.3.0.0</AssemblyVersion>
+        <FileVersion>1.3.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Viperinius.Plugin.NfoChapters/Parsers/MovieChapterNfoParser.cs
+++ b/Viperinius.Plugin.NfoChapters/Parsers/MovieChapterNfoParser.cs
@@ -9,10 +9,10 @@ using System.Threading.Tasks;
 using System.Xml;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
@@ -39,7 +39,7 @@ namespace Viperinius.Plugin.NfoChapters.Parsers
         private readonly IItemRepository _itemRepository;
         private readonly IFileSystem _fileSystem;
         private readonly IDirectoryService _directoryService;
-        private readonly IEncodingManager _encodingManager;
+        private readonly IChapterManager _chapterManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MovieChapterNfoParser"/> class.
@@ -50,7 +50,7 @@ namespace Viperinius.Plugin.NfoChapters.Parsers
         /// <param name="itemRepository">Instance of the <see cref="IItemRepository"/> interface.</param>
         /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
         /// <param name="directoryService">Instance of the <see cref="IDirectoryService"/> interface.</param>
-        /// <param name="encodingManager">Instance of the <see cref="IEncodingManager"/> interface.</param>
+        /// <param name="chapterManager">Instance of the <see cref="IChapterManager"/> interface.</param>
         public MovieChapterNfoParser(
             ILogger logger,
             ILoggerFactory loggerFactory,
@@ -58,7 +58,7 @@ namespace Viperinius.Plugin.NfoChapters.Parsers
             IItemRepository itemRepository,
             IFileSystem fileSystem,
             IDirectoryService directoryService,
-            IEncodingManager encodingManager)
+            IChapterManager chapterManager)
         {
             _logger = logger;
             _loggerFactory = loggerFactory;
@@ -66,7 +66,7 @@ namespace Viperinius.Plugin.NfoChapters.Parsers
             _itemRepository = itemRepository;
             _fileSystem = fileSystem;
             _directoryService = directoryService;
-            _encodingManager = encodingManager;
+            _chapterManager = chapterManager;
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Viperinius.Plugin.NfoChapters.Parsers
                     var sortedChapters = tmpItem.Item.Chapters.ToList();
                     sortedChapters.Sort((a, b) => a.StartPositionTicks.CompareTo(b.StartPositionTicks));
 
-                    var existingChapters = _itemRepository.GetChapters(movie);
+                    var existingChapters = _chapterManager.GetChapters(movie.Id);
                     if (existingChapters != null && existingChapters.Count > 0)
                     {
                         // Check if the NFO chapters differ from the existing ones
@@ -145,7 +145,7 @@ namespace Viperinius.Plugin.NfoChapters.Parsers
                         }
                     }
 
-                    _itemRepository.SaveChapters(movie.Id, sortedChapters);
+                    _chapterManager.SaveChapters(movie, sortedChapters);
                 }
                 catch (Exception ex)
                 {
@@ -155,7 +155,7 @@ namespace Viperinius.Plugin.NfoChapters.Parsers
                 // Extract images only if not supposed to be done via scheduled task
                 if ((Plugin.Instance?.Configuration.ExtractChapterImagesToPaths ?? false) && !(Plugin.Instance?.Configuration.ExtractChapterImagesTask ?? false))
                 {
-                    await new Tasks.ExtractChapterImagesTask(_loggerFactory.CreateLogger<Tasks.ExtractChapterImagesTask>(), _encodingManager, _libraryManager, _directoryService, _itemRepository, _fileSystem)
+                    await new Tasks.ExtractChapterImagesTask(_loggerFactory.CreateLogger<Tasks.ExtractChapterImagesTask>(), _chapterManager, _libraryManager, _directoryService, _fileSystem)
                         .RunExtraction(movie, cancellationToken).ConfigureAwait(false);
                 }
 

--- a/Viperinius.Plugin.NfoChapters/Savers/MovieChapterNfoSaver.cs
+++ b/Viperinius.Plugin.NfoChapters/Savers/MovieChapterNfoSaver.cs
@@ -9,11 +9,11 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
@@ -32,7 +32,7 @@ namespace Viperinius.Plugin.NfoChapters.Savers
         private readonly IFileSystem _fileSystem;
         private readonly IServerConfigurationManager _configurationManager;
         private readonly IProviderManager _providerManager;
-        private readonly IItemRepository _itemRepository;
+        private readonly IChapterManager _chapterManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MovieChapterNfoSaver"/> class.
@@ -41,19 +41,19 @@ namespace Viperinius.Plugin.NfoChapters.Savers
         /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
         /// <param name="configurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
         /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
-        /// <param name="itemRepository">Instance of the <see cref="IItemRepository"/> interface.</param>
+        /// <param name="chapterManager">Instance of the <see cref="IChapterManager"/> interface.</param>
         public MovieChapterNfoSaver(
             ILogger<MovieChapterNfoSaver> logger,
             IFileSystem fileSystem,
             IServerConfigurationManager configurationManager,
             IProviderManager providerManager,
-            IItemRepository itemRepository)
+            IChapterManager chapterManager)
         {
             _logger = logger;
             _fileSystem = fileSystem;
             _configurationManager = configurationManager;
             _providerManager = providerManager;
-            _itemRepository = itemRepository;
+            _chapterManager = chapterManager;
         }
 
         /// <summary>
@@ -156,8 +156,7 @@ namespace Viperinius.Plugin.NfoChapters.Savers
                 return;
             }
 
-            var videoWithChapters = new VideoWithChapters(video);
-            var chapters = _itemRepository.GetChapters(item);
+            var chapters = _chapterManager.GetChapters(item.Id).ToList();
 
             // do not save auto generated dummy chapters
             if (chapters.Count == 0 || Utils.AreDummyChapters(chapters))
@@ -211,7 +210,7 @@ namespace Viperinius.Plugin.NfoChapters.Savers
 
                 if (modifiedServerChapters)
                 {
-                    _itemRepository.SaveChapters(item.Id, chapters);
+                    _chapterManager.SaveChapters(video, chapters);
                 }
             }
 

--- a/Viperinius.Plugin.NfoChapters/Tasks/ExtractChapterImagesTask.cs
+++ b/Viperinius.Plugin.NfoChapters/Tasks/ExtractChapterImagesTask.cs
@@ -6,11 +6,10 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.MediaEncoding;
-using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
@@ -25,34 +24,30 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
     public class ExtractChapterImagesTask : IScheduledTask
     {
         private readonly ILogger<ExtractChapterImagesTask> _logger;
-        private readonly IEncodingManager _encodingManager;
+        private readonly IChapterManager _chapterManager;
         private readonly ILibraryManager _libraryManager;
         private readonly IDirectoryService _directoryService;
-        private readonly IItemRepository _itemRepository;
         private readonly IFileSystem _fileSystem;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExtractChapterImagesTask"/> class.
         /// </summary>
         /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
-        /// <param name="encodingManager">Instance of the <see cref="IEncodingManager"/> interface.</param>
+        /// <param name="chapterManager">Instance of the <see cref="IChapterManager"/> interface.</param>
         /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
         /// <param name="directoryService">Instance of the <see cref="IDirectoryService"/> interface.</param>
-        /// <param name="itemRepository">Instance of the <see cref="IItemRepository"/> interface.</param>
         /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
         public ExtractChapterImagesTask(
             ILogger<ExtractChapterImagesTask> logger,
-            IEncodingManager encodingManager,
+            IChapterManager chapterManager,
             ILibraryManager libraryManager,
             IDirectoryService directoryService,
-            IItemRepository itemRepository,
             IFileSystem fileSystem)
         {
             _logger = logger;
-            _encodingManager = encodingManager;
+            _chapterManager = chapterManager;
             _libraryManager = libraryManager;
             _directoryService = directoryService;
-            _itemRepository = itemRepository;
             _fileSystem = fileSystem;
         }
 
@@ -133,7 +128,7 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
         /// <returns>Task.</returns>
         public async Task RunExtraction(Video video, CancellationToken cancellationToken)
         {
-            var chapters = _itemRepository.GetChapters(video);
+            var chapters = _chapterManager.GetChapters(video.Id);
             var success = await RefreshChapterImages(video, chapters, true, true, cancellationToken).ConfigureAwait(false);
 
             if (!success)
@@ -183,7 +178,7 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
                 }
             }
 
-            var result = await _encodingManager.RefreshChapterImages(video, _directoryService, chapters, extractImages, saveChapters, cancellationToken).ConfigureAwait(false);
+            var result = await _chapterManager.RefreshChapterImages(video, _directoryService, chapters, extractImages, saveChapters, cancellationToken).ConfigureAwait(false);
             if (result)
             {
                 bool changesMade = false;
@@ -211,7 +206,7 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
 
                 if (changesMade)
                 {
-                    _itemRepository.SaveChapters(video.Id, chapters);
+                    _chapterManager.SaveChapters(video, chapters);
                     if (Plugin.Instance?.Configuration.EnableVerboseLogging ?? false)
                     {
                         _logger.LogInformation("Chapter changes were made for {Name}", video.Path);

--- a/Viperinius.Plugin.NfoChapters/Tasks/PostScanTask.cs
+++ b/Viperinius.Plugin.NfoChapters/Tasks/PostScanTask.cs
@@ -5,8 +5,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.IO;
@@ -26,7 +26,7 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
         private IItemRepository _itemRepository;
         private IFileSystem _fileSystem;
         private IDirectoryService _directoryService;
-        private IEncodingManager _encodingManager;
+        private IChapterManager _chapterManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PostScanTask" /> class.
@@ -37,7 +37,7 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
         /// <param name="itemRepository">Instance of the <see cref="IItemRepository"/> interface.</param>
         /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
         /// <param name="directoryService">Instance of the <see cref="IDirectoryService"/> interface.</param>
-        /// <param name="encodingManager">Instance of the <see cref="IEncodingManager"/> interface.</param>
+        /// <param name="chapterManager">Instance of the <see cref="IChapterManager"/> interface.</param>
         public PostScanTask(
             ILogger<PostScanTask> logger,
             ILoggerFactory loggerFactory,
@@ -45,7 +45,7 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
             IItemRepository itemRepository,
             IFileSystem fileSystem,
             IDirectoryService directoryService,
-            IEncodingManager encodingManager)
+            IChapterManager chapterManager)
         {
             _logger = logger;
             _loggerFactory = loggerFactory;
@@ -53,7 +53,7 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
             _itemRepository = itemRepository;
             _fileSystem = fileSystem;
             _directoryService = directoryService;
-            _encodingManager = encodingManager;
+            _chapterManager = chapterManager;
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Viperinius.Plugin.NfoChapters.Tasks
         /// <returns>Task.</returns>
         public Task Run(IProgress<double> progress, CancellationToken cancellationToken)
         {
-            return new MovieChapterNfoParser(_logger, _loggerFactory, _libraryManager, _itemRepository, _fileSystem, _directoryService, _encodingManager).Run(progress, cancellationToken);
+            return new MovieChapterNfoParser(_logger, _loggerFactory, _libraryManager, _itemRepository, _fileSystem, _directoryService, _chapterManager).Run(progress, cancellationToken);
         }
     }
 }

--- a/Viperinius.Plugin.NfoChapters/Viperinius.Plugin.NfoChapters.csproj
+++ b/Viperinius.Plugin.NfoChapters/Viperinius.Plugin.NfoChapters.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Viperinius.Plugin.NfoChapters</RootNamespace>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>$(AssemblyVersion)</FileVersion>
-    <Version>$(AssemblyVersion)</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
@@ -15,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.10.7" />
-    <PackageReference Include="Jellyfin.Model" Version="10.10.7" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.6" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -2,9 +2,9 @@
 name: "NFO Chapters"
 guid: "BE72D436-AB23-44B4-8625-9A8F3892D27A"
 imageUrl: "https://github.com/Viperinius/jellyfin-plugin-nfo-chapters/raw/master/viperinius-plugin-nfochapters.png"
-version: "1.2.0.0"
-targetAbi: "10.9.0.0"
-framework: "net8.0"
+version: "1.3.0.0"
+targetAbi: "10.11.0.0"
+framework: "net9.0"
 overview: "This plugin enables the use of chapter tags in NFOs"
 description: >
   This plugin extends the NFO parser for your Movies.
@@ -15,6 +15,12 @@ artifacts:
 - "Viperinius.Plugin.NfoChapters.dll"
 changelog: |2-
   # Changelog
+
+  ## [1.3.0.0] - 2026-03-27
+
+  ### Changed
+
+  - Updated for Jellyfin 10.11 compatibility (replaced IEncodingManager with IChapterManager, updated GetChapters/SaveChapters API)
 
   ## [1.2.0.0] - 2024-09-13
 


### PR DESCRIPTION
- Replace IEncodingManager with IChapterManager (removed in 10.11)
- Replace IItemRepository.GetChapters(BaseItem) with IChapterManager.GetChapters(Guid)
- Replace IItemRepository.SaveChapters with IChapterManager.SaveChapters
- Update target framework net8.0 -> net9.0
- Bump Jellyfin SDK to 10.11.6